### PR TITLE
change sonar project name to avoid ambiguities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
 
         <sonar.organization>fhhagenberg-sqe</sonar.organization>
         <sonar.projectKey>project-sqelevator-mcm-team-6-1</sonar.projectKey>
+        <sonar.projectName>ElevatorCC - Team 6</sonar.projectName>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     </properties>
 


### PR DESCRIPTION
I've changed the sonar project name to avoid ambiguities on SonarCloud.